### PR TITLE
Release v2.0.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
-    day: sunday
+    day: monday
     time: "10:00"
   open-pull-requests-limit: 10
-  target-branch: master
+  target-branch: development

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -54,6 +54,10 @@ RUN tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz \
 
 ###### MAIN START ######
 FROM docker.io/alpine:3.18
+
+ENV S6_CMD_WAIT_FOR_SERVICES=1
+ENV S6_CMD_WAIT_FOR_SERVICES_MAXTIME=0
+
 RUN apk add --no-cache \
             avahi \
             alsa-lib \


### PR DESCRIPTION
## Fix startup timeouts on slow devices
Give the `s6` services as much time as needed to perform startup/readiness without generating a timeout on slow devices (see https://github.com/mikebrady/shairport-sync/issues/1677)