### PR TITLE
v2.0.4

### DIFF
--- a/.github/workflows/publish_images.yml
+++ b/.github/workflows/publish_images.yml
@@ -6,6 +6,9 @@ on:
     types: [published]
   pull_request:
 
+env:
+  REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
@@ -28,7 +31,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ghcr.io/${{ github.repository_owner }}/${{ github.repository }}
+            ${{ env.REGISTRY_IMAGE }}
           flavor: latest=${{ startsWith(github.ref, 'refs/tags/') }}
           tags: |
             type=semver,pattern={{version}}

--- a/.github/workflows/publish_images.yml
+++ b/.github/workflows/publish_images.yml
@@ -45,7 +45,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6.15.0
+        uses: docker/build-push-action@v6.16.0
         with:
           context: .
           file: ./alpine.dockerfile

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -48,7 +48,7 @@ RUN fdupes -d -N /tmp-libs/ /usr/lib/
 
 # Install s6
 ADD https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-noarch.tar.xz \
-    https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-x86_64.tar.xz /tmp
+    https://github.com/just-containers/s6-overlay/releases/download/v${S6_OVERLAY_VERSION}/s6-overlay-x86_64.tar.xz /tmp/
 RUN tar -C / -Jxpf /tmp/s6-overlay-noarch.tar.xz \
     && tar -C / -Jxpf /tmp/s6-overlay-x86_64.tar.xz \
     && rm -rf /tmp/*

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -1,7 +1,7 @@
-ARG alpine_version=3.20
-ARG S6_OVERLAY_VERSION=3.2.0.0
+ARG alpine_version=3.21
+ARG S6_OVERLAY_VERSION=3.2.0.3
 
-FROM docker.io/alpine:${alpine_version} as builder
+FROM docker.io/alpine:${alpine_version} AS builder
 RUN apk add --no-cache \
     alpine-sdk \
     cmake \
@@ -19,7 +19,7 @@ RUN apk add --no-cache \
 ### SNAPCLIENT ###
 RUN git clone https://github.com/badaix/snapcast.git /snapcast \
     && cd snapcast \
-    && git checkout a31238a2fbf63c55c57dded9bfbe82e868f48cef
+    && git checkout 40ad2bac0ac59930fbabfda7cad41c6b2482c658
 
 WORKDIR /snapcast
 RUN cmake -S . -B build -DBUILD_SERVER=OFF \
@@ -34,7 +34,7 @@ RUN mkdir /snapclient-libs \
 ### SNAPCLIENT END ###
 
 ###### BASE START ######
-FROM docker.io/alpine:${alpine_version} as base
+FROM docker.io/alpine:${alpine_version} AS base
 ARG S6_OVERLAY_VERSION
 RUN apk add --no-cache \
     avahi \

--- a/alpine.dockerfile
+++ b/alpine.dockerfile
@@ -1,5 +1,5 @@
 ARG alpine_version=3.21
-ARG S6_OVERLAY_VERSION=3.2.0.3
+ARG S6_OVERLAY_VERSION=3.2.1.0
 
 FROM docker.io/alpine:${alpine_version} AS builder
 RUN apk add --no-cache \


### PR DESCRIPTION
## Important

Image location was moved from `ghcr.io/yubiuser/yubiuser/snapclient-docker` to `ghcr.io/yubiuser/snapclient-docker`  by https://github.com/yubiuser/snapclient-docker/pull/73!


Updates `s6-overlay` to `3.2.1.0`


