### PR TITLE
Update s6-overlay to 3.2.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG S6_OVERLAY_VERSION=3.2.2.0
+ARG S6_OVERLAY_VERSION=3.2.3.0
 
 FROM docker.io/alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS builder
 RUN apk add --no-cache \


### PR DESCRIPTION
https://github.com/just-containers/s6-overlay/releases/tag/v3.2.3.0